### PR TITLE
fix Nette 2.4 compatibility

### DIFF
--- a/src/IPub/FormPhone/Controls/Phone.php
+++ b/src/IPub/FormPhone/Controls/Phone.php
@@ -317,7 +317,7 @@ class Phone extends Forms\Controls\TextInput
 	 *
 	 * @throws Exceptions\InvalidArgumentException
 	 */
-	public function getControlPart($key)
+	public function getControlPart($key = NULL)
 	{
 		$name = $this->getHtmlName();
 

--- a/src/IPub/FormPhone/Controls/Phone.php
+++ b/src/IPub/FormPhone/Controls/Phone.php
@@ -307,7 +307,7 @@ class Phone extends Forms\Controls\TextInput
 	public function getControl()
 	{
 		return Utils\Html::el()
-			->add($this->getControlPart(static::FIELD_COUNTRY) . $this->getControlPart(static::FIELD_NUMBER));
+			->addHtml($this->getControlPart(static::FIELD_COUNTRY) . $this->getControlPart(static::FIELD_NUMBER));
 	}
 
 	/**


### PR DESCRIPTION
in nette/forms 2.4, `getControlPart` has been refactored up the hierarchy into `BaseControl`, but without an argument, resulting in the following warning:

```
Declaration of IPub\FormPhone\Controls\Phone::getControlPart($key) should be compatible with Nette\Forms\Controls\BaseControl::getControlPart()
```

Loosening the signature seems to help and has been used in nette/forms's `RadioList` as well, so I guess it's the right way to go
